### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,9 @@ on:
       - main
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/build_recognition.yml
+++ b/.github/workflows/build_recognition.yml
@@ -6,6 +6,9 @@ on:
       - main
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -12,6 +12,9 @@ on:
         options:
           - Home
 
+permissions:
+  contents: read
+
 jobs:
   deployment:
     runs-on: [self-hosted, iot]

--- a/.github/workflows/deployment_prediction.yml
+++ b/.github/workflows/deployment_prediction.yml
@@ -3,6 +3,9 @@ name: Deploy WaterSensor prediction on Environment
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   deployment:
     runs-on: [self-hosted, python]


### PR DESCRIPTION
Potential fix for [https://github.com/Zefek/WaterSensor/security/code-scanning/4](https://github.com/Zefek/WaterSensor/security/code-scanning/4)

Add an explicit `permissions` block at the workflow root so all jobs inherit minimal token scope unless overridden.  
Best single change here: in `.github/workflows/deployment.yml`, insert:

```yaml
permissions:
  contents: read
```

right after the `on:` section (before `jobs:`). This preserves existing functionality (checkout still works) while enforcing least privilege for `GITHUB_TOKEN`.

No imports/methods/dependencies are needed (YAML config only).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
